### PR TITLE
feat: support optional pull request title validation

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: 'Specify a comma separated list of allowed commit types'
     default: 'feat,fix,docs,style,refactor,test,build,perf,ci,chore,revert,merge,wip'
     required: false
+  include-pull-request-title:
+    description: 'Ensure the pull request title follows the conventional-commits standard'
+    default: 'false'
+    required: false
 
 runs:
   using: node20

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,23 +5,35 @@ import isValidCommitMessage from "./isValidCommitMesage";
 import extractCommits from "./extractCommits";
 
 async function run() {
-    core.info(
-        `ℹ️ Checking if commit messages are following the Conventional Commits specification...`
-    );
+    const allowedCommitTypes = core.getInput("allowed-commit-types").split(",");
+    const includePullRequestTitle = core.getBooleanInput("include-pull-request-title");
+
+    let hasErrors = false;
+    
+    if (includePullRequestTitle) {
+        core.info("ℹ️ Checking pull request title is following the Conventional Commits specification...");
+
+        const pullRequestTitle = context.payload.pull_request.title;
+        if (isValidCommitMessage(pullRequestTitle, allowedCommitTypes)) {
+            core.info(`✅ ${pullRequestTitle}`);
+        } else {
+            core.info(`🚩 ${pullRequestTitle}`);
+            hasErrors = true;
+        }
+    }
+
+    core.info("ℹ️ Checking if commit messages are following the Conventional Commits specification...");
 
     const extractedCommits = await extractCommits(context, core);
     if (extractedCommits.length === 0) {
-        core.info(`No commits to check, skipping...`);
+        core.info("No commits to check, skipping...");
         return;
     }
 
-    let hasErrors;
     core.startGroup("Commit messages:");
+
     for (let i = 0; i < extractedCommits.length; i++) {
         let commit = extractedCommits[i];
-
-        const allowedCommitTypes = core.getInput("allowed-commit-types").split(",");
-
         if (isValidCommitMessage(commit.message, allowedCommitTypes)) {
             core.info(`✅ ${commit.message}`);
         } else {
@@ -32,9 +44,7 @@ async function run() {
     core.endGroup();
 
     if (hasErrors) {
-        core.setFailed(
-            `🚫 According to the conventional-commits specification, some of the commit messages are not valid.`
-        );
+        core.setFailed("🚫 According to the conventional-commits specification, some of the commit messages are not valid.");
     } else {
         core.info("🎉 All commit messages are following the Conventional Commits specification.");
     }


### PR DESCRIPTION
Howdy @adrians5j 👋 First and foremost, appreciate your work on this action 🙏 Recently I found a scenario on a repo of our's where a PR was squash merged, taking the PR title as the commit message but the title itself didn't conform to conventional commit in the first place.

To combat this and avoid introducing another action for a separate step I wanted to propose the inclusion of an optional input, `include-pull-request-title`, to this action that would validate the title in addition to the commits when set to `true`.

Thoughts?